### PR TITLE
Add py36 to tox and fix upcoming issues.

### DIFF
--- a/parsevasp/incar.py
+++ b/parsevasp/incar.py
@@ -1,15 +1,14 @@
 #!/usr/bin/python
 import sys
-import os
-import numpy as np
 import logging
-import mmap
-import StringIO
+from io import StringIO
 # sys.path.append(os.path.dirname(__file__))
 # print sys.path
 
-import utils
-import constants
+from six import iteritems
+from past.builtins import basestring 
+
+from . import utils
 
 
 class Incar(object):
@@ -51,7 +50,7 @@ class Incar(object):
             self._prec = 12
         else:
             self._prec = prec
-        self._width = self._prec + 4    
+        self._width = self._prec + 4
 
         # check that only one argument is supplied
         if (incar_string is not None and incar_dict is not None) \
@@ -60,7 +59,7 @@ class Incar(object):
             self._logger.error("Please only supply one argument when "
                               "initializing Incar. Exiting.")
             sys.exit(1)
-            
+
         # check that at least one is supplied
         if (incar_string is None and incar_dict is None
                 and file_path is None):
@@ -80,7 +79,7 @@ class Incar(object):
             incar = self._from_list(incar_list)
         else:
             incar = self._from_dict(incar_dict)
-            
+
         # validate dictionary
         self.validate()
 
@@ -190,7 +189,7 @@ class Incar(object):
         """
 
         incar_dict = {}
-        for tag, value in incar.iteritems():
+        for tag, value in iteritems(incar):
             # check for comment in value, if so skip shuffle to comment
             comment = None
             if isinstance(value, str):
@@ -219,7 +218,7 @@ class Incar(object):
             incar_dict[clean_tag] = entry
 
         return incar_dict
-    
+
     def _convert_value_to_string(self, value):
         """Converts a value for an INCAR entry to a string that
         is compatible with VASP.
@@ -246,7 +245,7 @@ class Incar(object):
         # 1.0 - float
         # [1.0, 2.0, 3.0] - list of floats
 
-        
+
         if type(value) is list:
             # list of values (we know all are either string, int or float)
             string = ' '.join(map(str, value))
@@ -259,7 +258,7 @@ class Incar(object):
             string = str(value)
 
         return string
-    
+
     def validate(self):
         """Validate the content of the current Incar instance.
 
@@ -299,7 +298,7 @@ class Incar(object):
         Parameters
         ----------
         tag : string
-            The entry tag of the INCAR entry.        
+            The entry tag of the INCAR entry.
 
         """
 
@@ -314,7 +313,7 @@ class Incar(object):
         Parameters
         ----------
         tag : string
-            The entry tag of the INCAR entry.        
+            The entry tag of the INCAR entry.
         comment : bool, optional
             If set to True, the comment is also returned, otherwise
             not.
@@ -353,9 +352,9 @@ class Incar(object):
             A dictionary on INCAR compatible form.
 
         """
-        
+
         dictionary = {}
-        for key, entry in self.entries.iteritems():
+        for key, entry in iteritems(self.entries):
             dictionary[key] = entry.get_value()
 
         return dictionary
@@ -378,8 +377,8 @@ class Incar(object):
         string_object.close()
 
         return incar_string
-        
-        
+
+
     def write(self, file_path, comments=False):
         """Write the content of the current Incar instance to
         file.
@@ -393,11 +392,11 @@ class Incar(object):
             else not.
 
         """
-        
-        incar = utils.file_handler(file_path, status='w')        
+
+        incar = utils.file_handler(file_path, status='w')
         self._write(incar = incar)
-        utils.file_handler(file_handler=incar)        
-        
+        utils.file_handler(file_handler=incar)
+
     def _write(self, incar, comments=False):
         """Write the content of the current Incar instance to
         file or string.
@@ -452,7 +451,7 @@ class IncarItem(object):
         else:
             logging.basicConfig(level=logging.DEBUG)
             self._logger = logging.getLogger('IncarItem')
-        
+
         # clean tag and value
         clean_tag, clean_value, clean_comment = self._clean_entry(tag,
                                                                   value,
@@ -460,7 +459,7 @@ class IncarItem(object):
         self.tag = clean_tag
         self.value = clean_value
         self.comment = clean_comment
-        
+
     def get_tag(self):
         return self.tag
 
@@ -515,7 +514,7 @@ class IncarItem(object):
         # give a value what they would in INCAR
 
         # make sure we keep compatibility between Python 2 and 3
-        if isinstance(value, str) or isinstance(value, unicode):
+        if isinstance(value, basestring):
             if clean_tag == "system":
                 # if value is SYSTEM, treat it a bit special and
                 # leave its string intact but remove grub
@@ -541,7 +540,7 @@ class IncarItem(object):
                     # we have here also have a bool, so check that
                     cnt = self._test_string_for_bool(element)
                 clean_value.append(cnt)
-                
+
             # now if there is only one element in clean_value
             # remove list
             if len(clean_value) == 1:

--- a/parsevasp/kpoints.py
+++ b/parsevasp/kpoints.py
@@ -2,11 +2,11 @@
 import sys
 import logging
 import numpy as np
-from collections import Counter
-from decimal import getcontext as gctx
-import StringIO
+from io import StringIO
 
-import utils
+from six import iteritems
+
+from . import utils
 
 
 class Kpoints(object):
@@ -49,7 +49,7 @@ class Kpoints(object):
         else:
             self._prec = prec
         self._width = self._prec + 4
-            
+
         # check that only one argument is supplied
         if (kpoints_string is not None and kpoints_dict is not None) \
            or (kpoints_string is not None and file_path is not None) \
@@ -218,7 +218,7 @@ class Kpoints(object):
                     coordinate = np.asarray([float(element) for element in entry])
                     point = Kpoint(coordinate, 1.0)
                     points.append(point)
-                
+
         mode = "explicit"
         if automatic:
             mode = "automatic"
@@ -301,7 +301,7 @@ class Kpoints(object):
                 self._check_mode(mode = value)
             if entry == "num_kpoints":
                 self._check_num_kpoints(num_kpoints = value)
-                
+
             self.entries[entry] = value
 
     def delete_point(self, point_number):
@@ -361,7 +361,7 @@ class Kpoints(object):
         ----------
         entry : string
             Contains the entry to be checked.
-        
+
         """
 
         if not (("comment" in entry) or ("points" in entry) or
@@ -379,7 +379,7 @@ class Kpoints(object):
     def _check_comment(self, comment = None):
         """Check that the comment entry is present and
         is a string.
-        
+
         Parameters
         ----------
         comment, optional
@@ -410,7 +410,7 @@ class Kpoints(object):
             'points' key in the 'entries' is checked.
 
         """
-        
+
         if points is None:
             try:
                 points = self.entries["points"]
@@ -424,7 +424,7 @@ class Kpoints(object):
                 self._logger.error("The 'points' entry "
                                   "have to be a list. Exiting.")
                 sys.exit(1)
-        
+
     def _check_point(self, point = None):
         """Check that the point entry is a Kpoint() object.
 
@@ -453,7 +453,7 @@ class Kpoints(object):
                 self._logger.error("The 'point' "
                                   "is not a Kpoint() object. Exiting.")
                 sys.exit(1)
-                
+
     def _check_point_number(self, point_number):
         """Check that the point_number is an int and that
         it is not out of bounds.
@@ -464,7 +464,7 @@ class Kpoints(object):
             The point_number to be checked
 
         """
-        
+
         if not isinstance(point_number, int):
             self._logger.error("The supplied 'point_number' is "
                               "not an integer. Exiting.")
@@ -478,7 +478,7 @@ class Kpoints(object):
     def _check_shifts(self, shifts = None):
         """Check that the shifts are either None or
         a list of three floats.
-        
+
         Parameters
         ----------
         shifts : list, optional
@@ -494,7 +494,7 @@ class Kpoints(object):
                 self._logger.error("There is no key 'divitions' in "
                                   "'entries'. Exiting.")
                 sys.exit(1)
-        if shifts is not None:        
+        if shifts is not None:
             if not isinstance(shifts, list):
                 self._logger.error("The supplied 'shifts' is not a list. "
                                   "Exiting.")
@@ -507,9 +507,9 @@ class Kpoints(object):
                         sys.exit(1)
 
     def _check_tetra_volume(self, volume = None):
-        """Check that the volume of the tetrahedron is  
+        """Check that the volume of the tetrahedron is
         either None or a float.
-        
+
         Parameters
         ----------
         volume : float
@@ -525,15 +525,15 @@ class Kpoints(object):
                 self._logger.error("There is no key 'divitions' in "
                                   "'entries'. Exiting.")
                 sys.exit(1)
-        if volume is not None:        
+        if volume is not None:
             if not isinstance(volume, float):
                 self._logger.error("The supplied 'tetra_volume' is not a float. "
                                   "Exiting.")
-                        
+
     def _check_divisions(self, divisions = None):
         """Check that the divisions are either None or
         a list of three integers.
-        
+
         Parameters
         ----------
         divisions : list, optional
@@ -549,7 +549,7 @@ class Kpoints(object):
                 self._logger.error("There is no key 'divitions' in "
                                   "'entries'. Exiting.")
                 sys.exit(1)
-        if divisions is not None:        
+        if divisions is not None:
             if not isinstance(divisions, list):
                 self._logger.error("The supplied 'divisions' is not a list. "
                                   "Exiting.")
@@ -564,7 +564,7 @@ class Kpoints(object):
     def _check_tetra(self, tetra = None):
         """Check that tetra are either None or
         a list of four integers.
-        
+
         Parameters
         ----------
         tetra : list, optional
@@ -580,7 +580,7 @@ class Kpoints(object):
                 self._logger.error("There is no key 'divisions' in "
                                   "'entries'. Exiting.")
                 sys.exit(1)
-        if tetra is not None:        
+        if tetra is not None:
             if not isinstance(tetra, list):
                 self._logger.error("The supplied 'tetra' is not a list. "
                                   "Exiting.")
@@ -600,7 +600,7 @@ class Kpoints(object):
                             self._logger.error("Entry: " + str(entry) +
                                               " is not an integer. Exiting.")
                             sys.exit(1)
-                            
+
     def _check_centering(self, centering = None):
         """Check that the centering flag is valid.
 
@@ -632,7 +632,7 @@ class Kpoints(object):
         Parameters
         ----------
         num_kpoints : int, optional
-            The num_kpoints to be checked. If not supplied, the 
+            The num_kpoints to be checked. If not supplied, the
             num_kpoints of the current instance is checked.
 
         """
@@ -648,7 +648,7 @@ class Kpoints(object):
             self._logger.error("The 'num_kpoints' need to be an integer. "
                               "Exiting.")
             sys.exit(1)
-            
+
     def _check_mode(self, mode = None):
         """Check that the mode flag is valid.
 
@@ -673,7 +673,7 @@ class Kpoints(object):
                 self._logger.error("The supplied 'mode' have to be either "
                                   "explicit, automatic or line-mode. Exiting.")
                 sys.exit(1)
-                            
+
     def _validate(self):
         """Validate the content of entries
 
@@ -697,14 +697,14 @@ class Kpoints(object):
     def _to_cart(self, point):
 
         return point
-        
+
     def get(self, tag):
         """Return the value and comment of the entry with tag.
 
         Parameters
         ----------
         tag : string
-            The entry tag of the KPOINTS entry.        
+            The entry tag of the KPOINTS entry.
 
         Returns
         -------
@@ -731,9 +731,9 @@ class Kpoints(object):
             A dictionary on KPOINTS compatible form.
 
         """
-        
+
         dictionary = {}
-        for key, entry in self.entries.iteritems():
+        for key, entry in iteritems(self.entries):
             if key == 'points':
                 if entry is not None:
                     dictionary[key] = [[element.get_point(),
@@ -759,14 +759,14 @@ class Kpoints(object):
             current instance.
 
         """
-        
+
         string_object = StringIO.StringIO()
         self._write(kpoints = string_object)
         kpoints_string = string_object.getvalue()
         string_object.close()
 
         return poscar_string
-        
+
     def write(self, file_path):
         """ Write KPOINTS like files
 
@@ -781,7 +781,7 @@ class Kpoints(object):
         kpoints = utils.file_handler(file_path, status='w')
         self._write(kpoints = kpoints)
         utils.file_handler(file_handler=kpoints)
-        
+
     def _write(self, kpoints):
         """ Write KPOINTS like files to a file or string
 
@@ -878,7 +878,7 @@ class Kpoints(object):
             utils.remove_newline(kpoints)
 
 class Kpoint(object):
-    
+
     def __init__(self, point, weight, direct = True, logger=None):
         """A site, typically a position in POSCAR.
 
@@ -905,6 +905,6 @@ class Kpoint(object):
 
     def get_weight(self):
         return self.weight
-    
+
     def get_direct(self):
         return self.direct

--- a/parsevasp/outcar.py
+++ b/parsevasp/outcar.py
@@ -2,11 +2,8 @@
 import sys
 import logging
 import numpy as np
-from collections import Counter
-import StringIO
-from itertools import groupby
 
-import utils
+from . import utils
 
 
 class Outcar(object):
@@ -25,7 +22,7 @@ class Outcar(object):
             when printing files.
 
         """
-        
+
         self._file_path = file_path
         self._conserve_order = conserve_order
 
@@ -60,7 +57,7 @@ class Outcar(object):
                                    'point_group': {'static': [], 'dynamic': []}}
                       }
 
-        
+
         # parse parse parse
         self._parse()
 
@@ -117,7 +114,7 @@ class Outcar(object):
 
         config = ''
         for index, line in enumerate(outcar):
-            
+
             # first, fetch the symmetry
             if line.strip().startswith('Analysis of symmetry for initial positions (statically)'):
                 config = 'static'
@@ -148,7 +145,7 @@ class Outcar(object):
             if line.strip().startswith('Subroutine INISYM returns'):
                 prim_line = outcar[index+2].strip().split()
                 self._data['symmetry']['primitive_translations'].append(int(prim_line[2]))
-                    
+
             # then the elastic tensors etc. in kBar
             if line.strip().startswith('ELASTIC MODULI  (kBar)'):
                 tensor = []
@@ -166,7 +163,7 @@ class Outcar(object):
                     tensor.append([float(item) for item in outcar[index+idx].strip().split()[1:]])
                 self._data['elastic_moduli']['total'] = np.asarray(tensor)
 
-                
+
     def get_symmetry(self):
         """Return the symmetry.
 

--- a/parsevasp/poscar.py
+++ b/parsevasp/poscar.py
@@ -3,10 +3,11 @@ import sys
 import logging
 import numpy as np
 from collections import Counter
-import StringIO
-from itertools import groupby
+from io import StringIO
 
-import utils
+from six import iteritems
+
+from . import utils
 
 
 class Poscar(object):
@@ -144,7 +145,7 @@ class Poscar(object):
                         site.set_velocities(velocities)
                     site.set_direct(True)
 
-                    
+
     def _from_list(self, poscar):
         """Go through the list and analyze for = and ; in order to
         deentangle grouped entries etc.
@@ -747,7 +748,7 @@ class Poscar(object):
 
 
         dictionary = {}
-        for key, entry in self.entries.iteritems():
+        for key, entry in iteritems(self.entries):
             if key == 'sites':
                 sites_temp = []
                 for element in entry:
@@ -968,7 +969,7 @@ class Site(object):
 
         self.position = position
         return
-    
+
     def get_position(self):
         """Return the position.
 
@@ -1008,7 +1009,7 @@ class Site(object):
         self.velocities = velocities
         return
 
-    
+
     def get_velocities(self):
         """Return the velocities.
 
@@ -1050,14 +1051,14 @@ class Site(object):
 
         self.direct = direct
         return
-    
+
     def get_direct(self):
         """Return the direct status of the coordinate.
 
         Returns
         -------
         direct : bool
-            True if the coordinates are given in direct coordinates, 
+            True if the coordinates are given in direct coordinates,
             otherwise for direct, False.
 
         """

--- a/parsevasp/vasprun.py
+++ b/parsevasp/vasprun.py
@@ -6,8 +6,8 @@ import logging
 import mmap
 import copy
 
-import constants
-import utils
+from . import constants
+from . import utils
 
 from lxml import etree
 
@@ -1669,7 +1669,7 @@ class Xml(object):
 
         Returns
         -------
-        eigenvalues : ndarray            
+        eigenvalues : ndarray
             An ndarray containing the
             eigenvalues for each spin, band and
             kpoint index.
@@ -1704,7 +1704,7 @@ class Xml(object):
                                                    entry_ispin2, len(self._data['kpoints']))
 
         return eigenvalues
-    
+
     def _fetch_eigenvelocitiesw(self, xml):
         """Fetch the eigenvelocities and eigenvalues..
 
@@ -2718,7 +2718,7 @@ class Xml(object):
 
         epsilon_ion = self._data["dielectrics"]["epsilon_ion"]
         return epsilon_ion
-    
+
     def get_fermi_level(self):
 
         fermi_level = self._data["dos"]["total"]["fermi_level"]

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,6 @@ setup(
 	         'Topic :: Scientific/Engineering :: Physics',
 	         'License :: OSI Approved :: MIT License',
 	         'Programming Language :: Python :: 2.7'],
-  install_requires=['numpy', 'lxml'],
+  install_requires=['numpy', 'lxml', 'six', 'future'],
   extras_require={'dev': ['pytest', 'pytest-cov', 'click']}
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,13 @@
 [tox]
-envlist = py27
+envlist = py27,py36
 
 [testenv]
 passenv = TRAVIS TRAVIS_*
 
-deps = 
+deps =
     .[dev]
     coveralls
 
-commands = 
+commands =
     pytest --cov-report=term-missing --cov={envsitepackagesdir}/parsevasp
     python {toxinidir}/ops/run_coveralls.py


### PR DESCRIPTION
This is an attempt at creating compatibility with Python 3.6.

- Added py36 to tox environments
- Replaced direct imports (e.g. ``import utils``) with relative ones (``from . import utils``)
- Use ``past.builtins.basestring`` instead of ``str`` and ``unicode`` for string type matching
- Use ``six.iteritems`` instead of the ``.iteritems()`` method
- Remove some unused imports.

Added dependencies: ``six``, ``future``.