### PR TITLE
Added setup.json to the manifet

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
+include setup.json
 include parsevasp/incar_tags.yml


### PR DESCRIPTION
In the previous commit which added `setup.json` it was not included in the manifest and is thus missing at pypi. Added in this commit.